### PR TITLE
Implement get historical range wrapper

### DIFF
--- a/pkg/routes/routes.go
+++ b/pkg/routes/routes.go
@@ -41,4 +41,6 @@ func RegisterAllRoutes(r *mux.Router) {
 	r.HandleFunc("/financego", checkPiquette)
 	// Register all /auth routes
 	registerAuthRoutes(r)
+
+	registerStockRoutes(r)
 }

--- a/pkg/routes/stocks.go
+++ b/pkg/routes/stocks.go
@@ -1,0 +1,39 @@
+package routes
+
+import (
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/bluedresscapital/coattails/pkg/stockings"
+
+	"github.com/gorilla/mux"
+)
+
+func registerStockRoutes(r *mux.Router) {
+	log.Print("Registering stock routes")
+	s := r.PathPrefix("/stock").Subrouter()
+	s.HandleFunc("/quote/{ticker}", stockQuoteHandler).Methods("GET")
+}
+
+func stockQuoteHandler(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	startStr := r.URL.Query().Get("start")
+	endStr := r.URL.Query().Get("end")
+	start, err := time.Parse("2006-01-02", startStr)
+	if err != nil {
+		log.Printf("Invalid start string: %s", startStr)
+		return
+	}
+	end, err := time.Parse("2006-01-02", endStr)
+	if err != nil {
+		log.Printf("Invalid end string: %s", endStr)
+		return
+	}
+	prices, err := stockings.GetHistoricalRange(stockings.FingoPack{}, vars["ticker"], start, end)
+	if err != nil {
+		log.Printf("Error in getting historical range: %v", err)
+		return
+	}
+	writeJsonResponse(w, *prices)
+}

--- a/pkg/stockings/fingopack.go
+++ b/pkg/stockings/fingopack.go
@@ -71,7 +71,11 @@ func piqConvertToHistoricalRange(stocks *piqHistoricalStocks) *HistoricalStocks 
 	ret := new(HistoricalStocks)
 
 	for i := 0; i < len(*stocks); i++ {
-		*ret = append(*ret, HistoricalStock{time.Unix(int64((*stocks)[i].Timestamp), 0), (*stocks)[i].AdjClose})
+		date := time.Unix(int64((*stocks)[i].Timestamp), 0)
+		*ret = append(*ret, HistoricalStock{
+			Date:  time.Date(date.Year(), date.Month(), date.Day(), 0, 0, 0, 0, time.UTC),
+			Price: (*stocks)[i].AdjClose,
+		})
 	}
 
 	return ret

--- a/pkg/wardrobe/stockquotes.go
+++ b/pkg/wardrobe/stockquotes.go
@@ -1,0 +1,44 @@
+package wardrobe
+
+import (
+	"time"
+
+	"github.com/shopspring/decimal"
+)
+
+type StockQuote struct {
+	Stock       string          `json:"stock"`
+	Price       decimal.Decimal `json:"price"`
+	Date        time.Time       `json:"date"`
+	IsValidDate bool            `json:"is_valid_date"`
+}
+
+func UpsertStockQuote(quote StockQuote) error {
+
+	_, err := db.Exec(`
+		INSERT INTO stock_quotes (stock_id, price, date, is_valid_date)
+			SELECT stocks.id, $2, $3, $4
+			FROM stocks
+			WHERE ticker=$1
+		ON CONFLICT(stock_id, date) DO UPDATE
+		SET price=$2, is_valid_date=$4`,
+		quote.Stock, quote.Price, quote.Date, quote.IsValidDate)
+	return err
+}
+
+func FetchStockQuote(ticker string, date time.Time) (*StockQuote, bool, error) {
+	rows, err := db.Query(`
+		SELECT s.ticker, q.price, q.date, q.is_valid_date 
+		FROM stock_quotes q
+		JOIN stocks s ON s.id=q.stock_id
+		WHERE s.ticker=$1 AND q.date=$2`, ticker, date)
+	if err != nil {
+		return nil, false, err
+	}
+	if !rows.Next() {
+		return nil, false, nil
+	}
+	var sq StockQuote
+	err = rows.Scan(&sq.Stock, &sq.Price, &sq.Date, &sq.IsValidDate)
+	return &sq, true, err
+}


### PR DESCRIPTION
We now have a wrapper around our stock API! Calls with the same start and end date ranges should only need to call the stock API _once_